### PR TITLE
rev to 0.06 in prep for publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.6-dev
+## 0.0.6
 
 * Add 'experimental' messaging to the readme
 * Update the pubspec `repository` field

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: grpc_cronet
 description: Flutter plugin that provides Cronet-based grpc client implementation.
-version: 0.0.6-dev
+version: 0.0.6
 repository: https://github.com/dart-lang/grpc_cronet
 
 environment:


### PR DESCRIPTION
- rev to 0.06 in prep for publishing

cc @aam; Alex, after this lands, do you mind publishing a  new version? I'd like to capture the update to the `repository` field (the published version is currently pointing to `aam/grpc_cronet`).