### PR TITLE
Replace pub run with dart run

### DIFF
--- a/ffigen.yaml
+++ b/ffigen.yaml
@@ -1,9 +1,9 @@
-# Run with `flutter pub run ffigen --config ffigen.yaml`.
+# Run with `dart run ffigen --config ffigen.yaml`.
 name: GrpcCronetBindings
 description: |
   Bindings for `src/grpc_cronet.h`.
 
-  Regenerate bindings with `flutter pub run ffigen --config ffigen.yaml`.
+  Regenerate bindings with `dart run ffigen --config ffigen.yaml`.
 output: 'lib/grpc_cronet_bindings_generated.dart'
 compiler-opts:
   - '-Isrc/third_party/grpc_support'

--- a/lib/grpc_cronet_bindings_generated.dart
+++ b/lib/grpc_cronet_bindings_generated.dart
@@ -13,7 +13,7 @@ import 'dart:ffi' as ffi;
 
 /// Bindings for `src/grpc_cronet.h`.
 ///
-/// Regenerate bindings with `flutter pub run ffigen --config ffigen.yaml`.
+/// Regenerate bindings with `dart run ffigen --config ffigen.yaml`.
 ///
 class GrpcCronetBindings {
   /// Holds the symbol lookup function.


### PR DESCRIPTION
Following up on https://github.com/dart-lang/pub/issues/4737, this PR replaces deprecated `pub run` commands with `dart run`.